### PR TITLE
fix: prevent binaries from being removed prematurely

### DIFF
--- a/artifacts/Generic.Scanner.Thor.yaml
+++ b/artifacts/Generic.Scanner.Thor.yaml
@@ -55,7 +55,8 @@ sources:
               headers=dict(
                   `Authorization`=PortalKey
               ),
-              tempfile_extension=".zip"
+              tempfile_extension=".zip",
+              remove_last=TRUE
         )
         LET TmpDir <= tempdir(remove_last=TRUE)
         LET Unzipped <= SELECT * FROM unzip(filename=ThorZIP.Content, output_directory=TmpDir)

--- a/artifacts/Generic.Scanner.ThorCloud.yaml
+++ b/artifacts/Generic.Scanner.ThorCloud.yaml
@@ -42,7 +42,8 @@ sources:
                   `type` = (Type[0]).t,
                   `token` = Token
               ),
-              tempfile_extension=".exe"
+              tempfile_extension=".exe",
+              remove_last=TRUE
         )
         LET Chmod <= SELECT * FROM if(condition={SELECT OS FROM info() WHERE NOT OS =~ "windows" },
                                     then={SELECT * FROM execve(argv=["chmod", "+x", ThorZIP.Content[0]])}


### PR DESCRIPTION
Fixes the premature removal of the downloaded binaries, which resulted in them not being able to be executed.

Fixes #5 